### PR TITLE
Add 'Build' GHA status badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Virtual Receptionist accommodation management system's API.
 
+[![Build](https://github.com/jbence1994/virtual-receptionist-api/actions/workflows/build.yml/badge.svg)](https://github.com/jbence1994/virtual-receptionist-api/actions/workflows/build.yml)
+
 [Contributing Guide](.github/CONTRIBUTING.md)
 
 TODO.


### PR DESCRIPTION
Adding reference link (status badge) to build GHA in README.md